### PR TITLE
feat: add basic auth support to API requests

### DIFF
--- a/src/components/RoutersList.test.tsx
+++ b/src/components/RoutersList.test.tsx
@@ -4,7 +4,7 @@ import RoutersList from "./RoutersList";
 
 describe("RoutersList", () => {
   it("should render loading state initially", () => {
-    const useTraefikDataMock = () => ({
+    const useTraefikDataMock = (_apiUrl: string, _basicAuth?: string) => ({
       loading: true,
       error: null,
       routers: [],
@@ -17,7 +17,7 @@ describe("RoutersList", () => {
   });
 
   it("should render error state", () => {
-    const useTraefikDataMock = () => ({
+    const useTraefikDataMock = (_apiUrl: string, _basicAuth?: string) => ({
       loading: false,
       error: new Error("Test Error"),
       routers: [],
@@ -52,7 +52,7 @@ describe("RoutersList", () => {
         type: "loadbalancer",
       },
     ];
-    const useTraefikDataMock = () => ({
+    const useTraefikDataMock = (_apiUrl: string, _basicAuth?: string) => ({
       loading: false,
       error: null,
       routers,

--- a/src/components/RoutersList.tsx
+++ b/src/components/RoutersList.tsx
@@ -9,12 +9,14 @@ import RouterItem from "./RouterItem";
 
 interface RoutersListProps {
   apiUrl: string;
+  basicAuth?: string;
   useTraefikDataHook?: typeof useTraefikData;
   ignorePatterns?: string[];
 }
 
 const RoutersList: React.FC<RoutersListProps> = ({
   apiUrl,
+  basicAuth,
   useTraefikDataHook = useTraefikData,
   ignorePatterns = [],
 }) => {
@@ -35,7 +37,7 @@ const RoutersList: React.FC<RoutersListProps> = ({
     loading,
     error,
     lastUpdated,
-  } = useTraefikDataHook(apiUrl) as any;
+  } = useTraefikDataHook(apiUrl, basicAuth) as any;
 
   // Calculate available screen space
   const headerHeight = 1; // Search bar

--- a/src/hooks/useTraefikData.ts
+++ b/src/hooks/useTraefikData.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { getRouters, getServices } from "../api/traefik";
 import type { Router, Service } from "../types/traefik";
 
-export const useTraefikData = (apiUrl: string) => {
+export const useTraefikData = (apiUrl: string, basicAuth?: string) => {
   const [routers, setRouters] = useState<Router[]>([]);
   const [services, setServices] = useState<Service[]>([]);
   const [loading, setLoading] = useState(true);
@@ -17,8 +17,8 @@ export const useTraefikData = (apiUrl: string) => {
       setLoading(true);
       setError(null);
       const [routersResult, servicesResult] = await Promise.all([
-        getRouters(apiUrl),
-        getServices(apiUrl),
+        getRouters(apiUrl, basicAuth),
+        getServices(apiUrl, basicAuth),
       ]);
 
       if (routersResult.isErr()) {
@@ -46,7 +46,7 @@ export const useTraefikData = (apiUrl: string) => {
     // Disabled auto-refresh for now to prevent excessive API calls
     // const intervalId = setInterval(fetchData, 5000); // Refresh every 5 seconds
     // return () => clearInterval(intervalId); // Cleanup on unmount
-  }, [apiUrl, refreshTick]);
+  }, [apiUrl, basicAuth, refreshTick]);
   const refresh = () => setRefreshTick((n) => n + 1);
 
   // Auto-refresh every 10s
@@ -56,7 +56,7 @@ export const useTraefikData = (apiUrl: string) => {
       setRefreshTick((n) => n + 1);
     }, 10_000);
     return () => clearInterval(id);
-  }, [apiUrl]);
+  }, [apiUrl, basicAuth]);
 
   return { routers, services, loading, error, refresh, lastUpdated };
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -61,6 +61,7 @@ async function main() {
   let apiUrl: string | undefined;
   const ignorePatterns: string[] = [];
   let insecure = false;
+  const basicAuth = process.env.TRAEFIKTOP_BASIC_AUTH;
 
   const pushIgnore = (val?: string) => {
     if (!val) return;
@@ -168,7 +169,11 @@ async function main() {
   try {
     render(
       <ErrorBoundary>
-        <RoutersList apiUrl={apiUrl} ignorePatterns={ignorePatterns} />
+        <RoutersList
+          apiUrl={apiUrl}
+          basicAuth={basicAuth}
+          ignorePatterns={ignorePatterns}
+        />
       </ErrorBoundary>,
       {
         stdout: mutableStdout as any,


### PR DESCRIPTION
## Summary
- read TRAEFIKTOP_BASIC_AUTH at startup
- forward basic auth credentials to API requests
- update tests for new hook signature

## Testing
- `bun run lint:fix`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68b30ec30f3483258cd4c1358b2c92b5