### PR TITLE
feat: add refresh shortcut and legend

### DIFF
--- a/src/components/RoutersList.test.tsx
+++ b/src/components/RoutersList.test.tsx
@@ -9,6 +9,7 @@ describe("RoutersList", () => {
       error: null,
       routers: [],
       services: [],
+      refresh: () => {},
     });
     const { lastFrame } = render(
       <RoutersList apiUrl="" useTraefikDataHook={useTraefikDataMock} />,
@@ -22,6 +23,7 @@ describe("RoutersList", () => {
       error: new Error("Test Error"),
       routers: [],
       services: [],
+      refresh: () => {},
     });
     const { lastFrame } = render(
       <RoutersList apiUrl="" useTraefikDataHook={useTraefikDataMock} />,
@@ -57,6 +59,7 @@ describe("RoutersList", () => {
       error: null,
       routers,
       services,
+      refresh: () => {},
     });
     const { lastFrame } = render(
       <RoutersList apiUrl="" useTraefikDataHook={useTraefikDataMock} />,
@@ -65,5 +68,24 @@ describe("RoutersList", () => {
     // Test shows search header and router count
     expect(output).toContain("🔍 Press / to search");
     expect(output).toContain("1 routers");
+  });
+
+  it("should refresh data when 'r' is pressed", async () => {
+    let refreshed = false;
+    const useTraefikDataMock = () => ({
+      loading: false,
+      error: null,
+      routers: [],
+      services: [],
+      refresh: () => {
+        refreshed = true;
+      },
+    });
+    const { stdin } = render(
+      <RoutersList apiUrl="" useTraefikDataHook={useTraefikDataMock} />,
+    );
+    stdin.write("r");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(refreshed).toBe(true);
   });
 });

--- a/src/components/RoutersList.tsx
+++ b/src/components/RoutersList.tsx
@@ -35,6 +35,7 @@ const RoutersList: React.FC<RoutersListProps> = ({
     loading,
     error,
     lastUpdated,
+    refresh,
   } = useTraefikDataHook(apiUrl) as any;
 
   // Calculate available screen space
@@ -60,7 +61,7 @@ const RoutersList: React.FC<RoutersListProps> = ({
     allRouters,
     allServices,
     availableHeight,
-    { ignorePatterns },
+    { ignorePatterns, refresh },
   );
 
   if (loading) {
@@ -295,7 +296,7 @@ const RoutersList: React.FC<RoutersListProps> = ({
           </Text>
           <Text dimColor>{flash ?? ""}</Text>
           <Text>
-            sort: {state.sortMode === "status" ? "dead" : "name"} • s: sort
+            {`sort: ${state.sortMode === "status" ? "dead" : "name"} • s: sort • r: refresh`}
           </Text>
         </Box>
       )}

--- a/src/tui/useTui.ts
+++ b/src/tui/useTui.ts
@@ -10,7 +10,7 @@ export const useTui = (
   routers: Router[],
   services: Service[],
   availableHeight: number,
-  options?: { ignorePatterns?: string[] },
+  options?: { ignorePatterns?: string[]; refresh?: () => void },
 ) => {
   const [state, dispatch] = useReducer(tuiReducer, initialState);
   const ignore = (options?.ignorePatterns || []).map((s) => s.toLowerCase());
@@ -116,7 +116,10 @@ export const useTui = (
         return;
       }
 
-      // no manual refresh key
+      if (input === "r" || input === "R") {
+        options?.refresh?.();
+        return;
+      }
 
       // Sorting controls
       if (input === "s") {


### PR DESCRIPTION
## Summary
- add optional refresh callback and r key to trigger it
- display `r: refresh` in footer legend
- test refresh shortcut

## Testing
- `bun run lint:fix`
- `bun run format`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68b59f835d0c83259302f7b8f337170e