### PR TITLE
feat: add basic auth support to API requests

### DIFF
--- a/src/components/RoutersList.test.tsx
+++ b/src/components/RoutersList.test.tsx
@@ -9,6 +9,7 @@ describe("RoutersList", () => {
       error: null,
       routers: [],
       services: [],
+      refresh: () => {},
     });
     const { lastFrame } = render(
       <RoutersList apiUrl="" useTraefikDataHook={useTraefikDataMock} />,
@@ -22,6 +23,7 @@ describe("RoutersList", () => {
       error: new Error("Test Error"),
       routers: [],
       services: [],
+      refresh: () => {},
     });
     const { lastFrame } = render(
       <RoutersList apiUrl="" useTraefikDataHook={useTraefikDataMock} />,
@@ -57,6 +59,7 @@ describe("RoutersList", () => {
       error: null,
       routers,
       services,
+      refresh: () => {},
     });
     const { lastFrame } = render(
       <RoutersList apiUrl="" useTraefikDataHook={useTraefikDataMock} />,
@@ -65,5 +68,24 @@ describe("RoutersList", () => {
     // Test shows search header and router count
     expect(output).toContain("🔍 Press / to search");
     expect(output).toContain("1 routers");
+  });
+
+  it("should refresh data when 'r' is pressed", async () => {
+    let refreshed = false;
+    const useTraefikDataMock = () => ({
+      loading: false,
+      error: null,
+      routers: [],
+      services: [],
+      refresh: () => {
+        refreshed = true;
+      },
+    });
+    const { stdin } = render(
+      <RoutersList apiUrl="" useTraefikDataHook={useTraefikDataMock} />,
+    );
+    stdin.write("r");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(refreshed).toBe(true);
   });
 });

--- a/src/components/RoutersList.tsx
+++ b/src/components/RoutersList.tsx
@@ -37,6 +37,7 @@ const RoutersList: React.FC<RoutersListProps> = ({
     loading,
     error,
     lastUpdated,
+    refresh,
   } = useTraefikDataHook(apiUrl, basicAuth) as any;
 
   // Calculate available screen space
@@ -62,7 +63,7 @@ const RoutersList: React.FC<RoutersListProps> = ({
     allRouters,
     allServices,
     availableHeight,
-    { ignorePatterns },
+    { ignorePatterns, refresh },
   );
 
   if (loading) {
@@ -297,7 +298,7 @@ const RoutersList: React.FC<RoutersListProps> = ({
           </Text>
           <Text dimColor>{flash ?? ""}</Text>
           <Text>
-            sort: {state.sortMode === "status" ? "dead" : "name"} • s: sort
+            {`sort: ${state.sortMode === "status" ? "dead" : "name"} • s: sort • r: refresh`}
           </Text>
         </Box>
       )}

--- a/src/tui/useTui.ts
+++ b/src/tui/useTui.ts
@@ -10,7 +10,7 @@ export const useTui = (
   routers: Router[],
   services: Service[],
   availableHeight: number,
-  options?: { ignorePatterns?: string[] },
+  options?: { ignorePatterns?: string[]; refresh?: () => void },
 ) => {
   const [state, dispatch] = useReducer(tuiReducer, initialState);
   const ignore = (options?.ignorePatterns || []).map((s) => s.toLowerCase());
@@ -116,7 +116,10 @@ export const useTui = (
         return;
       }
 
-      // no manual refresh key
+      if (input === "r" || input === "R") {
+        options?.refresh?.();
+        return;
+      }
 
       // Sorting controls
       if (input === "s") {


### PR DESCRIPTION
## Summary
- forward basic auth credentials when fetching Traefik data
- merge latest main to include refresh shortcut support and tests

## Testing
- `bun run lint:fix`
- `bun run format`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a78dcbfc8325897609dae303945b